### PR TITLE
Avoid error when a package start by py

### DIFF
--- a/autodiscover/autodiscover.py
+++ b/autodiscover/autodiscover.py
@@ -39,4 +39,4 @@ class AutoDiscover:
         return list(path.glob('**/*.py'))
 
     def __normalize_module_name(self, module):
-        return '.'.join(module.parts).replace('.py', '')
+        return '.'.join(module.parts)[: -len(module.suffix)]


### PR DESCRIPTION
This fix error when name o package start by py.

Cut the suffix of module name.
![image](https://user-images.githubusercontent.com/8469909/88965144-f2818a00-d26f-11ea-9361-fbea70b99292.png)
